### PR TITLE
rust unwrap result related fixes for clear errors

### DIFF
--- a/contracts/dexter_generator/generator/src/contract.rs
+++ b/contracts/dexter_generator/generator/src/contract.rs
@@ -1462,7 +1462,7 @@ fn query_pool_info(
         .tokens_per_block
         .checked_mul(alloc_point)?
         .checked_div(config.total_alloc_point)
-        .unwrap_or_else(|_| Uint128::zero());
+        .unwrap_or(Uint128::zero());
 
     Ok(PoolInfoResponse {
         alloc_point,
@@ -1510,15 +1510,12 @@ pub fn query_simulate_future_reward(
 
     let lp_token = deps.api.addr_validate(&lp_token)?;
     let alloc_point = get_alloc_point(&cfg.active_pools, &lp_token);
-    let n_blocks = Uint128::from(future_block)
-        .checked_sub(env.block.height.into())
-        .unwrap_or_else(|_| Uint128::zero());
+    let n_blocks = Uint128::from(future_block).checked_sub(env.block.height.into())?;
 
     let simulated_reward = n_blocks
         .checked_mul(cfg.tokens_per_block)?
         .checked_mul(alloc_point)?
-        .checked_div(cfg.total_alloc_point)
-        .unwrap_or_else(|_| Uint128::zero());
+        .checked_div(cfg.total_alloc_point)?;
 
     Ok(simulated_reward)
 }

--- a/contracts/dexter_generator/generator/src/error.rs
+++ b/contracts/dexter_generator/generator/src/error.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::{OverflowError, StdError};
+use cosmwasm_std::{DivideByZeroError, OverflowError, StdError};
 use thiserror::Error;
 
 /// This enum describes generator contract errors!
@@ -70,6 +70,12 @@ pub enum ContractError {
 
 impl From<OverflowError> for ContractError {
     fn from(o: OverflowError) -> Self {
+        StdError::from(o).into()
+    }
+}
+
+impl From<DivideByZeroError> for ContractError {
+    fn from(o: DivideByZeroError) -> Self {
         StdError::from(o).into()
     }
 }

--- a/contracts/dexter_generator/vesting/src/contract.rs
+++ b/contracts/dexter_generator/vesting/src/contract.rs
@@ -252,7 +252,7 @@ pub fn claim(
                 contract_addr: config.token_addr.to_string(),
                 funds: vec![],
                 msg: to_binary(&Cw20ExecuteMsg::Transfer {
-                    recipient: recipient.unwrap_or_else(|| info.sender.to_string()),
+                    recipient: recipient.unwrap_or(info.sender.to_string()),
                     amount: claim_amount,
                 })?,
             })]);

--- a/contracts/router/src/contract.rs
+++ b/contracts/router/src/contract.rs
@@ -244,8 +244,8 @@ pub fn execute_multihop_swap(
         multiswap_request: multiswap_request,
         offer_asset: first_hop_swap_request.asset_out,
         prev_ask_amount: current_ask_balance,
-        recipient: recipient.unwrap_or_else(|| info.sender),
-        minimum_receive: minimum_receive.unwrap_or_else(|| Uint128::zero()),
+        recipient: recipient.unwrap_or(info.sender),
+        minimum_receive: minimum_receive.unwrap_or(Uint128::zero()),
     }
     .to_cosmos_msg(&env.contract.address)?;
     execute_msgs.push(arb_chain_msg);

--- a/contracts/vault/src/contract.rs
+++ b/contracts/vault/src/contract.rs
@@ -457,7 +457,7 @@ pub fn execute_add_to_registry(
             pool_config
                 .fee_info
                 .developer_addr
-                .unwrap_or_else(|| Addr::unchecked("None".to_string())),
+                .unwrap_or(Addr::unchecked("None".to_string())),
         )
         .add_attribute(
             "is_instantiation_disabled",

--- a/contracts/weighted_pool/src/approx_pow.rs
+++ b/contracts/weighted_pool/src/approx_pow.rs
@@ -21,7 +21,7 @@ pub fn calculate_pow(
     exp: Decimal,
     precision: Option<Decimal>,
 ) -> StdResult<Decimal> {
-    let precision = precision.unwrap_or_else(|| Decimal::from_str("0.00000001").unwrap());
+    let precision = precision.unwrap_or(Decimal::from_str("0.00000001").unwrap());
     if exp.is_zero() || base.is_zero() {
         return Ok(base);
     };

--- a/packages/dexter/src/helper.rs
+++ b/packages/dexter/src/helper.rs
@@ -370,13 +370,12 @@ pub fn is_valid_symbol(symbol: &str) -> bool {
 /// ## Params
 /// * **message_info** is an object of type [`MessageInfo`]
 pub fn find_sent_native_token_balance(message_info: &MessageInfo, denom: &str) -> Uint128 {
-    let empty_coin = Coin::new(0u128, denom);
-    let coin = message_info
+    message_info
         .funds
         .iter()
         .find(|x| x.clone().denom == denom)
-        .unwrap_or_else(|| &empty_coin);
-    coin.amount
+        .map(|x| x.amount)
+        .unwrap_or(Uint128::zero())
 }
 
 // Returns the number of tokens charged as total fee

--- a/packages/dexter/src/querier.rs
+++ b/packages/dexter/src/querier.rs
@@ -39,18 +39,15 @@ pub fn query_token_balance(
     account_addr: Addr,
 ) -> StdResult<Uint128> {
     // load balance from the token contract
-    let res: Cw20BalanceResponse = querier
+    querier
         .query(&QueryRequest::Wasm(WasmQuery::Smart {
             contract_addr: String::from(contract_addr),
             msg: to_binary(&Cw20QueryMsg::Balance {
                 address: String::from(account_addr),
             })?,
         }))
-        .unwrap_or_else(|_| Cw20BalanceResponse {
-            balance: Uint128::zero(),
-        });
-
-    Ok(res.balance)
+        .map(|res: Cw20BalanceResponse| Ok(res.balance))
+        .unwrap_or(Ok(Uint128::zero()))
 }
 
 /// ## Description


### PR DESCRIPTION
Some fixes around error unwrapping to zero values. 
made sure we rarely do that where it's actually intended. 
In all other cases, put correct error messages in responses to help debug issues more easily.