### PR TITLE
fix: Oak audit fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ env
 scripts/node_modules
 scripts/persistenceJS
 .idea
+.DS_Store

--- a/contracts/keeper/src/contract.rs
+++ b/contracts/keeper/src/contract.rs
@@ -40,7 +40,7 @@ pub fn instantiate(
     set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
 
     let cfg = Config {
-        owner: msg.owner,
+        owner: deps.api.addr_validate(msg.owner.as_str())?,
     };
 
     CONFIG.save(deps.storage, &cfg)?;

--- a/contracts/multi_staking/src/contract.rs
+++ b/contracts/multi_staking/src/contract.rs
@@ -271,13 +271,14 @@ fn claim_unallocated_reward(
 
     // Send the unclaimed reward to the reward schedule creator
     let msg = build_transfer_token_to_user_msg(
-        reward_schedule.asset,
+        reward_schedule.asset.clone(),
         reward_schedule.creator,
         creator_claimable_reward_state.amount,
     )?;
 
     let event = Event::new("dexter-multistaking::claim_unallocated_reward")
         .add_attribute("reward_schedule_id", reward_schedule_id.to_string())
+        .add_attribute("asset", reward_schedule.asset.as_string())
         .add_attribute("amount", creator_claimable_reward_state.amount.to_string());
 
     Ok(Response::new().add_event(event).add_message(msg))
@@ -996,13 +997,13 @@ fn withdraw_pending_reward(
 ) -> ContractResult<()> {
     let pending_reward = asset_staker_info.pending_reward;
 
-    let event = Event::new("dexter-multistaking::withdraw_reward")
-        .add_attribute("user", user)
-        .add_attribute("lp_token", lp_token)
-        .add_attribute("asset", asset_staker_info.asset.to_string())
-        .add_attribute("amount", pending_reward);
-
     if pending_reward > Uint128::zero() {
+        let event = Event::new("dexter-multistaking::withdraw_reward")
+            .add_attribute("user", user)
+            .add_attribute("lp_token", lp_token)
+            .add_attribute("asset", asset_staker_info.asset.to_string())
+            .add_attribute("amount", pending_reward);
+
         let res = response
             .clone()
             .add_message(build_transfer_token_to_user_msg(


### PR DESCRIPTION
* oak-6: Owner address is not validated - **Fixed**
* oak-19: Multistaking contract address is not validated - **Fixed**
* oak-20: Unvalidated fee update - It is already validated in vault `execute_update_pool_config`, and only vault can call the fee update for a pool.
* oak-21: Proposal start delay is not validated - We have a use case where we might want it to be zero. So, it seems fine as is. This control is upto the owner, if they make a mistake, they can just update it again.
* oak-38: Reward information is not emitted along with the amount - **Fixed**
* oak-39: Events are emitted even though no reward is withdrawn - **Fixed**
* oak-40: Duplicate execution when updating lp_token_code_id - **Fixed**
* oak-41: Paused attribute is not emitted when updating pool configurations - **Fixed**